### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ You have the ability to set a number of variables that affect the JSComments plu
 
 These options can exist in two places. Primarily, your user defaults will be set within the **jscomments.yaml** file in the `user/config/plugins/` directory. If you do not have a `user/config/plugins/` already, create the folder as it will enable you to change the default settings of the plugin without losing these updates in the event that the plugin is updated and/or reinstalled later on.
 
-Alterantively, you can override these defaults within the
+Alternatively, you can override these defaults within the
 
 Here are the variables available:
 
 ```
-enable: true # Enable / Disable the plugin
+enabled: true # Enable / Disable the plugin
 
 provider: "disqus" # (disqus | intensedebate | facebook | muut)
 


### PR DESCRIPTION
The sentence on 49 is incomplete and I'm not sure what you were going to say. 

At the beginning of the readme, it says that the plugin is enabled by default, but it is not actually enabled by default. Should either change the readme or change the default setting.

Once I noticed that enable/enabled issue, the plugin is working great, thanks!