### PR TITLE
Added basic multilang support for JSComments for Disqus

### DIFF
--- a/jscomments.php
+++ b/jscomments.php
@@ -60,7 +60,7 @@ class JSCommentsPlugin extends Plugin
         $template_file = 'plugins/jscomments/' . $this->config->get('provider') . '.html.twig';
         $template_vars = $this->config->get('providers.' . $this->config->get('provider'));
 
-        return $this->grav['twig']->twig()->render($template_file, $template_vars);
+        return $this->grav['twig']->processTemplate($template_file, $template_vars);
     }
 
     public function jscommentsCountFunction($shortname = '')

--- a/jscomments.yaml
+++ b/jscomments.yaml
@@ -5,6 +5,7 @@ provider: ""
 providers:
   disqus:
     shortname: ""
+    default_lang: en
 
   intensedebate:
     acct: ""

--- a/templates/plugins/jscomments/disqus.html.twig
+++ b/templates/plugins/jscomments/disqus.html.twig
@@ -1,6 +1,9 @@
 <div id="jscomments">
   <div id="disqus_thread"></div>
   <script type="text/javascript">
+    var disqus_config = function () { 
+        this.language = "{{ grav.language.getActive ?: default_lang }}";
+    };
     var disqus_shortname  = '{{ shortname|e }}'; // required: replace example with your forum shortname
     var disqus_title      = '{{ title|default(page.title)|e }}';
     var disqus_identifier = '{{ identifier|default(page.url(true))|e }}';


### PR DESCRIPTION
- I changed the `render`function of the `.php`file to the grav native function `processTemplate` so that grav variable grav.language.getActive is available.
- I added a default language for disqus comments. 
- Added disqus config variable to loading script in twig to load the comments in the specific language if it is available in Disqus: https://help.disqus.com/customer/portal/articles/466249 


Pending: 
- Checking whether the language translation is really available in Disqus and falling back to the default language if it is not.
- Translating the noscript message.